### PR TITLE
Fix runtime release crash and add functionality to scene.hpp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
-[submodule "extern/godot-engine"]
+[submodule "engine"]
 	path = extern/godot-engine
 	url = https://github.com/godotengine/godot.git
 	branch = 4.2
-[submodule "extern/godot-cpp"]
+[submodule "godot/godot-cpp"]
 	path = extern/godot-cpp
 	url = https://github.com/godotengine/godot-cpp.git
 	branch = 4.2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
-[submodule "engine"]
+[submodule "extern/godot-engine"]
 	path = extern/godot-engine
 	url = https://github.com/godotengine/godot.git
 	branch = 4.2
-[submodule "godot/godot-cpp"]
+[submodule "extern/godot-cpp"]
 	path = extern/godot-cpp
 	url = https://github.com/godotengine/godot-cpp.git
 	branch = 4.2

--- a/src/entity/level.cpp
+++ b/src/entity/level.cpp
@@ -28,6 +28,10 @@ namespace rl
         godot::Node* box{ this->find_child(name::level::physics_box) };
         m_physics_box = gdcast<godot::RigidBody2D>(box);
 
+        resource::preload::packed_scene<Player> player_scene{ path::scene::Player };
+        m_player = player_scene.instantiate();
+        m_player->set_controller(memnew(PlayerController));
+
         this->add_child(m_player);
         this->add_child(m_projectile_spawner);
 

--- a/src/entity/level.hpp
+++ b/src/entity/level.hpp
@@ -50,8 +50,7 @@ namespace rl
         std::atomic<bool> m_active{ false };
         godot::Node* m_background{ nullptr };
         ProjectileSpawner* m_projectile_spawner{ memnew(rl::ProjectileSpawner) };
-        resource::preload::scene<Player> player_scene{ path::scene::Player };
-        Player* m_player{ player_scene.instantiate(memnew(PlayerController)) };
+        Player* m_player{ nullptr };
         godot::RigidBody2D* m_physics_box{ nullptr };
     };
 }

--- a/src/entity/projectile/projectile_spawner.hpp
+++ b/src/entity/projectile/projectile_spawner.hpp
@@ -43,6 +43,6 @@ namespace rl
         // the time point that keeps track of when the last projectile was spawned.
         clock_t::time_point m_prev_spawn_time{ clock_t::now() };
         // preloaded packed scene that will be instantiated per spawn
-        resource::preload::scene<Projectile> m_scene{ path::scene::Bullet };
+        resource::preload::packed_scene<Projectile> m_scene{ path::scene::Bullet };
     };
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,8 +8,8 @@ namespace rl
 {
     Main::Main()
     {
-        resource::preload::scene<Level> level{ path::scene::Level1 };
-        resource::preload::scene<MainDialog> dialog{ path::ui::MainDialog };
+        resource::preload::packed_scene<Level> level{ path::scene::Level1 };
+        resource::preload::packed_scene<MainDialog> dialog{ path::ui::MainDialog };
 
         m_active_level = level.instantiate();
         runtime_assert(m_active_level != nullptr);

--- a/src/util/conversions.hpp
+++ b/src/util/conversions.hpp
@@ -19,18 +19,18 @@ namespace rl::inline utils
     struct gd_str_conv
     {
         explicit constexpr gd_str_conv(TStr&& s)
-            : m_str{ std::move(s) }
+            : m_str{ std::forward<TStr>(s) }
         {
         }
 
         explicit operator godot::String()
-            requires std::same_as<std::string>
+            requires std::same_as<TStr, std::string>
         {
             return godot::String(m_str.c_str());
         }
 
         explicit operator godot::String()
-            requires std::same_as<std::string_view>
+            requires std::same_as<TStr, std::string_view>
         {
             return godot::String(m_str.data());
         }
@@ -62,25 +62,10 @@ namespace rl::inline utils
     }
 
     template <>
-    inline auto to(const godot::String& in) -> std::string_view
-    {
-        static_assert(std::is_same_v<godot::String, std::remove_cvref_t<decltype(in)>>);
-        return std::string_view(in.ascii().ptr());
-    }
-
-    template <>
     inline auto to(const godot::StringName& in) -> std::string
     {
         static_assert(std::is_same_v<godot::StringName, std::remove_cvref_t<decltype(in)>>);
         godot::String tmp(in);
-        return std::string(tmp.ascii().ptr());
-    }
-
-    template <>
-    inline auto to(const godot::StringName& in) -> std::string_view
-    {
-        static_assert(std::is_same_v<godot::StringName, std::remove_cvref_t<decltype(in)>>);
-        godot::String tmp(in);
-        return std::string_view(tmp.ascii().ptr());
+        return std::string(tmp.utf8().ptr());
     }
 }

--- a/src/util/conversions.hpp
+++ b/src/util/conversions.hpp
@@ -14,6 +14,29 @@
 
 namespace rl::inline utils
 {
+    template <typename TStr>
+    struct GDStrConv
+    {
+        explicit constexpr GDStrConv(TStr&& s)
+            : m_str{ std::move(s) }
+        {
+        }
+
+        explicit operator godot::String()
+            requires std::same_as<std::string>
+        {
+            return godot::String(m_str.c_str());
+        }
+
+        explicit operator godot::String()
+            requires std::same_as<std::string_view>
+        {
+            return godot::String(m_str.data());
+        }
+
+        TStr m_str{};
+    };
+
     template <typename TOut, typename TIn>
         requires std::derived_from<std::remove_cvref_t<TIn>, godot::Object>
     constexpr inline TOut* gdcast(TIn* obj)

--- a/src/util/conversions.hpp
+++ b/src/util/conversions.hpp
@@ -14,10 +14,11 @@
 
 namespace rl::inline utils
 {
+	/** Converts std string types to godot::String at compile time */
     template <typename TStr>
-    struct GDStrConv
+    struct gd_str_conv
     {
-        explicit constexpr GDStrConv(TStr&& s)
+        explicit constexpr gd_str_conv(TStr&& s)
             : m_str{ std::move(s) }
         {
         }

--- a/src/util/conversions.hpp
+++ b/src/util/conversions.hpp
@@ -14,7 +14,7 @@
 
 namespace rl::inline utils
 {
-	/** Converts std string types to godot::String at compile time */
+    /** Converts std string types to godot::String at compile time */
     template <typename TStr>
     struct gd_str_conv
     {

--- a/src/util/scene.hpp
+++ b/src/util/scene.hpp
@@ -2,62 +2,84 @@
 
 #include <concepts>
 
-#include <godot_cpp/classes/dir_access.hpp>
-#include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/packed_scene.hpp>
 #include <godot_cpp/classes/resource.hpp>
 #include <godot_cpp/classes/resource_loader.hpp>
+#include <godot_cpp/classes/resource_saver.hpp>
 #include <godot_cpp/classes/scene_tree.hpp>
 #include <godot_cpp/classes/window.hpp>
 
 #include "core/assert.hpp"
 #include "util/conversions.hpp"
 
-namespace rl
-{
-    class Character;
-}
-
 namespace rl::inline utils
 {
-    namespace scene::node
+    namespace scene
     {
-        template <typename TNode>
-            requires std::derived_from<TNode, godot::Node>
-        static inline void set_unique_name(TNode* node, const char* name)
+        namespace node
         {
-            runtime_assert(node != nullptr);
-            node->set_name(name);
-            node->set_unique_name_in_owner(true);
-        }
-    }
+            template <typename TNode>
+                requires std::derived_from<TNode, godot::Node>
+            static inline void set_unique_name(TNode* node, const char* name)
+            {
+                runtime_assert(node != nullptr);
+                node->set_name(name);
+                node->set_unique_name_in_owner(true);
+            }
 
-    namespace scene::tree
-    {
-        template <typename TNode>
-            requires std::derived_from<TNode, godot::Node>
-        static inline godot::SceneTree* get(TNode* node)
-        {
-            godot::SceneTree* scene_tree{ node->get_tree() };
-            return scene_tree;
-        }
-
-        template <typename TNode>
-            requires std::derived_from<TNode, godot::Node>
-        static inline godot::Node* edited_root(TNode* node)
-        {
-            godot::Node* edited_root{ node->get_tree()->get_edited_scene_root() };
-            return edited_root;
+            template <typename TNodeA, typename TNodeB>
+                requires std::derived_from<TNodeB, godot::Node> &&
+                         std::derived_from<TNodeA, godot::Node>
+            static inline void set_owner(TNodeA* node, TNodeB* owner)
+            {
+                for (auto child : node->get_children())
+                {
+                    child.owner = owner;
+                    set_owner(child, owner);
+                }
+            }
         }
 
-        template <typename TNode>
-            requires std::derived_from<TNode, godot::Node>
-        static inline godot::Node* root_node(TNode* node)
+        namespace tree
         {
-            godot::SceneTree* scene_tree{ tree::get(node) };
-            godot::Window* root_window{ scene_tree->get_root() };
-            godot::Node* root_node{ gdcast<godot::Node>(root_window) };
-            return root_node;
+            template <typename TNode>
+                requires std::derived_from<TNode, godot::Node>
+            static inline godot::SceneTree* get(TNode* node)
+            {
+                godot::SceneTree* scene_tree{ node->get_tree() };
+                return scene_tree;
+            }
+
+            template <typename TNode>
+                requires std::derived_from<TNode, godot::Node>
+            static inline godot::Node* edited_root(TNode* node)
+            {
+                godot::Node* edited_root{ node->get_tree()->get_edited_scene_root() };
+                return edited_root;
+            }
+
+            template <typename TNode>
+                requires std::derived_from<TNode, godot::Node>
+            static inline godot::Node* root_node(TNode* node)
+            {
+                godot::SceneTree* scene_tree{ tree::get(node) };
+                godot::Window* root_window{ scene_tree->get_root() };
+                godot::Node* root_node{ gdcast<godot::Node>(root_window) };
+                return root_node;
+            }
+        }
+
+        namespace packer
+        {
+            template <typename TNode>
+                requires std::derived_from<TNode, godot::Node>
+            static inline godot::PackedScene* pack(TNode* node)
+            {
+                node::set_owner(node, node);
+                godot::PackedScene* package = memnew(godot::PackedScene);
+                package->pack(node);
+                return package;
+            }
         }
     }
 
@@ -71,49 +93,67 @@ namespace rl::inline utils
             }
         }
 
+        namespace saver
+        {
+            static inline godot::ResourceSaver* get()
+            {
+                return godot::ResourceSaver::get_singleton();
+            }
+        }
+
         namespace preload
         {
             template <typename TObj, typename TScene = godot::PackedScene>
                 requires std::derived_from<TScene, godot::Resource> &&
                          std::convertible_to<TObj, godot::Object>
-            class scene
+            class packed_scene
             {
             public:
                 using scene_t = TScene;
                 using object_t = TObj;
 
-            public:
-                scene(const char* resource_path)
+                /*Pack as preload from path*/
+                packed_scene(godot::String resource_load_path)
                 {
-                    auto fh{ godot::FileAccess::open(resource_path, godot::FileAccess::READ) };
-                    bool file_access_success{ !fh.is_null() };
+                    godot::ResourceLoader* resource_loader{ resource::loader::get() };
+
+                    bool file_access_success{ resource_loader->exists(resource_load_path) };
                     runtime_assert(file_access_success);
 
                     if (file_access_success)
                     {
-                        godot::ResourceLoader* resource_loader{ resource::loader::get() };
-                        m_packed_resource = resource_loader->load(resource_path);
+                        m_packed_resource = resource_loader->load(resource_load_path);
                         initialized = m_packed_resource.is_valid();
                     }
                 }
 
-                template <typename... TArgs>
-                [[nodiscard]] auto instantiate(TArgs... args) -> TObj*
+                /*Pack from existing instance*/
+                packed_scene(godot::Node* node)
                 {
-                    assertion(initialized, "instantiation invoked from uninitialized scene loader");
+                    m_packed_resource = scene::packer::pack(node);
+                    initialized = m_packed_resource.is_valid();
+                }
+
+                [[nodiscard]] auto instantiate() -> object_t*
+                {
+                    assertion(initialized,
+                              "Resource instantiation invoked from uninitialized scene loader.");
                     if (!initialized) [[unlikely]]
                         return nullptr;
 
-                    TObj* obj{ gdcast<TObj>(m_packed_resource->instantiate()) };
+                    object_t* obj{ gdcast<object_t>(m_packed_resource->instantiate()) };
                     runtime_assert(obj != nullptr);
 
-                    if constexpr (std::is_base_of_v<Character, object_t>)
-                    {
-                        if (obj != nullptr)
-                            obj->set_controller(args...);
-                    }
-
                     return obj;
+                }
+
+                void save(godot::String& resource_save_path)
+                {
+                    if (initialized)
+                    {
+                        auto error = saver::get()->save(m_packed_resource, resource_save_path);
+                        assertion(error != godot::Error::OK, "Packed resource save failed.");
+                    }
                 }
 
             private:

--- a/src/util/scene.hpp
+++ b/src/util/scene.hpp
@@ -27,7 +27,7 @@ namespace rl::inline utils
                 node->set_unique_name_in_owner(true);
             }
 
-			/** Sets the owner of a node and all it's children. */
+            /** Sets the owner of a node and all it's children. */
             template <typename TNodeA, typename TNodeB>
                 requires std::derived_from<TNodeB, godot::Node> &&
                          std::derived_from<TNodeA, godot::Node>
@@ -154,7 +154,7 @@ namespace rl::inline utils
                     return obj;
                 }
 
-				/** Save this resource to specified path. */
+                /** Save this resource to specified path. */
                 void save(godot::String& resource_save_path)
                 {
                     if (initialized)


### PR DESCRIPTION
**Notable changes:**
- level.cpp: In order to complete the functionality cycle of scene packing, added:
  - node::set_owner
  - packer::pack - constructs and returns a PackedScene* from a godot::Node*
  - resource::saver::get - returns ResourceSaver* (we already had loader::get which returns ResourceLoader* here so I'd asume it's not a bad spot)
  I use these on my own project and thought it would be nice if roguelite had this functionality, as a base library of sorts, but
  I'd understand if it were considered out of scope for the game itself, since it doesn't really require it.
- level.cpp: Renamed scene class to "packed_scene" to better represent what the class contains.
- level.cpp: Added an overloaded constructor for packed_scene, now accepting a pointer to an existing node for packing into the packed_scene object, while preserving the original constructor that takes a path for ResourceLoader.
- level.cpp: Added save member function to packed_scene, enabling the packed resource.
- level.cpp: Removed FileAccess::open check in favour of ResourceLoader::exists, solving a release runtime crash.
- level.cpp: Removed hacky "std::is_base_of_v<Character>" that does set_controller for objects which are Characters, in favour of actually calling that method right after the object is created, decoupling scene.hpp from Character instances.
- conversions.hpp: Added gd_str_conv, might be useful for compile time conversions. Not actually used anywhere in roguelite, but I tested it on my own project and it works ok.

There's ambiguity between the terms "resource" and "scene" throughout level.cpp's packed_scene class (a scene seems to be considered a resource in godot).
But I think referring to scenes as resources is alright.

I tested the specific additions (such as packing from instanced node and saving packed resource) on my roguelite templated project and the overall functionality and intent for it works good for me.
Of course I also tested this branch of the game in debug from VSC, and in release as windows standalone (where it now runs fine, I believe it wouldn't have run for anyone previously).

I thought of adding some tests to prove all this stuff works, but really they'd just be a useless apendage to the sample roguelite game. Can still do it if required though.