### PR TITLE
Default generated .gitmodules submodule nametags

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
-[submodule "engine"]
+[submodule "extern/godot-engine"]
 	path = extern/godot-engine
 	url = https://github.com/godotengine/godot.git
 	branch = 4.2
-[submodule "godot/godot-cpp"]
+[submodule "extern/godot-cpp"]
 	path = extern/godot-cpp
 	url = https://github.com/godotengine/godot-cpp.git
 	branch = 4.2

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,21 +1,7 @@
 {
     "recommendations": [
         "ms-vscode.cpptools",
-        "twxs.cmake",
-        "josetr.cmake-language-support-vscode",
         "ms-vscode.cmake-tools",
-        "eamodio.gitlens",
-        "alfish.godot-files",
-        "ms-python.python",
-        "ms-vscode-remote.remote-ssh",
-        "ms-vscode.remote-explorer",
-        "yzhang.markdown-all-in-one",
-        "foxundermoon.shell-format",
-        "calro.vscode-theme-one-dark-muted",
-        "jeff-hykin.better-cpp-syntax",
-        "ibm.output-colorizer",
         "xaver.clang-format",
-        "bierner.docs-view",
-        "donjayamanne.githistory"
     ]
 }


### PR DESCRIPTION
In order to prevent issues when making a clean/templated setup from roguelite, and since each submodule's nametag isn't used or referenced from anywhere else in the whole roguelite environment, I think it would be best if these submodule nametags were same as if newly generated.

In essence I just changed the submodules names in .gitmodules.

This affects the godot-cpp and godot-engine submodules, which are the only ones without a default nametag in .gitmodules.