### PR TITLE
Straightforward fix for on_character_rotate error

### DIFF
--- a/src/entity/character/character.cpp
+++ b/src/entity/character/character.cpp
@@ -84,8 +84,8 @@ namespace rl
     [[signal_slot]]
     void Character::on_character_rotate(double rotation_angle, double delta_time)
     {
-        double smoothed_angle = godot::Math::lerp_angle(this->get_rotation(), rotation_angle,
-                                                        m_rotation_speed * delta_time);
+        const double smoothed_angle = godot::Math::lerp_angle(
+            static_cast<double>(this->get_rotation()), rotation_angle, m_rotation_speed * delta_time);
         this->set_rotation(smoothed_angle);
     }
 


### PR DESCRIPTION
I added a cast that converts float to double when obtaining current character rotation, for the character rotation calculation.

This is a very simple fix, if anything more premeditated is to be done, this PR can be interpreted as an issue, for the project currently gives an error with this for everyone pulling it for the fist time, I thought I'd add this easy fix. There may be better solutions, I just didn't investigate further.

Someone suggested the use of real_t (godot macro for either float or double depending on a certain extension compile option), but I'm not convinced that A. That would be a proper solution, B. If it is a proper solution, it would potentially make sense in other areas of the project, even for general use when developing godot-cpp applications. (I don't know enough about real_t use cases to make this decision right now).